### PR TITLE
Implemented resume training for separated epochs 

### DIFF
--- a/const.py
+++ b/const.py
@@ -29,3 +29,9 @@ MODEL_PATH: str = 'model.pth'
 CONVERGENCE_THRESHOLD: int = 3
 
 MAX_NON_IMPROVEMENT_EPOCHS: int = 5
+
+# Whether or not to use full or partial dataset
+PARTIAL_LOAD: bool = False
+
+# Checkpoint interval
+SAVE_EVERY_N_EPOCHS: int == 1

--- a/data.py
+++ b/data.py
@@ -12,7 +12,7 @@ from torchvision.transforms import Resize
 from const import *
 from log_cfg import logger
 
-def load_dataset(partial : bool = True) -> Tuple[DataLoader, DataLoader, DataLoader]:
+def load_dataset(partial : bool = PARTIAL_LOAD) -> Tuple[DataLoader, DataLoader, DataLoader]:
     """
     Loads the dataset partially
 
@@ -92,7 +92,7 @@ if __name__ == '__main__':
     from tqdm import tqdm
     import shutil
 
-    train_loader, test_loader, val_loader = load_dataset(partial=True)
+    train_loader, test_loader, val_loader = load_dataset(partial=PARTIAL_LOAD)
 
     # serialize the data loaders
     torch.save(train_loader, 'train_loader.pth')
@@ -112,22 +112,22 @@ if __name__ == '__main__':
     
     # Iterate through a few batches to check data loader behavior
     for batch_idx, (data, targets) in enumerate(train_loader):
-        if batch_idx < 2:  # Print information for the first 2 batches
-            logger.info(f"Batch {batch_idx}:")
-            logger.info(f"  Data shape: {data.shape}")
-            logger.info(f"  Targets shape: {targets.shape}")
+       #  if batch_idx < 2:  # Print information for the first 2 batches
+        logger.info(f"Batch {batch_idx}:")
+        logger.info(f"  Data shape: {data.shape}")
+        logger.info(f"  Targets shape: {targets.shape}")
         
     # Visualize a few samples (you can use matplotlib or another library for this)
     import matplotlib.pyplot as plt
     
     for batch_idx, (data, targets) in enumerate(train_loader):
         try:
-            if batch_idx < 2:  # Visualize the first 2 batches
-                for i in range(data.size(0)):  # Visualize individual samples in the batch
-                    sample_image = data[i].permute(1, 2, 0)  # Rearrange channels for visualization
-                    plt.imshow(sample_image)
-                    plt.title(f"Class: {train_loader.dataset.classes[targets[i]]}")
-                    plt.show()
+            # if batch_idx < 2:  # Visualize the first 2 batches
+            for i in range(data.size(0)):  # Visualize individual samples in the batch
+                sample_image = data[i].permute(1, 2, 0)  # Rearrange channels for visualization
+                plt.imshow(sample_image)
+                plt.title(f"Class: {train_loader.dataset.classes[targets[i]]}")
+                plt.show()
         except Exception as e:
             logger.error(e)
             break

--- a/train.py
+++ b/train.py
@@ -113,7 +113,7 @@ if __name__ == "__main__":
         # Load the model
         m = load_model(args.filename)
     else:
-        m = model.BotanicamModel()
+        
 
         if args.resume:
             # Train model or resume from a checkpoint
@@ -123,7 +123,7 @@ if __name__ == "__main__":
                 val_loader)
         else:
             # Train from scratch
-
+            m = model.BotanicamModel()
             m = train(
                 train_loader=train_loader,
                 val_loader=val_loader,

--- a/train.py
+++ b/train.py
@@ -117,7 +117,7 @@ if __name__ == "__main__":
 
         if args.resume:
             # Train model or resume from a checkpoint
-            m.resume_training(
+            resume_training(
                 args.resume, 
                 train_loader, 
                 val_loader)


### PR DESCRIPTION
* Training the first epoch took about 7h on ~ 85% GPU utilization. 
* This wasn't sustainable for training 30 epochs in one sitting as I must allow for my GPU to have a break

```test.py```
Added
```python
resume_training(self, checkpoint_path: str, train_loader: DataLoader, val_loader: DataLoader)
 ```
* The function loads the data for the last epoch produced. 
* The filepath of the last checkpoint can be passed in by running 
* ```python train.py --resume checkpoint/checkpoint_epoch_{num}``` in repo dir




```model.py```
Updated 
```python 
train(
     self,
     train_loader: torch.utils.data.DataLoader,
     val_loader: torch.utils.data.DataLoader,
     epochs: int = EPOCHS,
     lr: float = LR,
     skip_validation: bool = False,
     checkpoint_number: int = 0
     ) -> None:
```

* The output epochs are now formatted to ```checkpoint_epoch__{num}.pth``` in the ```checkpoints``` folder. Both are initialised if they don't exist.

* Added parameter ```checkpoint_number``` which is automatically passed from ```resume_training()``` so that logging iteration numbers are correct

